### PR TITLE
Remove form-data dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "cloudflare-workers-toolkit": "0.0.6",
-    "form-data": "^2.3.3",
     "fs-extra": "^7.0.1",
     "node-fetch": "^2.3.0",
     "webpack": "^4.25.1"


### PR DESCRIPTION
Removed `form-data` from package.json dependencies. I don't see it being used anywhere.