### PR TITLE
Refactor single script and add support for namespaces

### DIFF
--- a/deploy/lib/multiscript.js
+++ b/deploy/lib/multiscript.js
@@ -18,7 +18,7 @@
  */
 const BB = require("bluebird");
 const webpack = require("../../utils/webpack");
-const ms = require("../../shared/multiscript");
+const allScripts = require("../../shared/allScripts");
 
 module.exports = {
   async multiScriptDeploy(functionObject) {
@@ -30,9 +30,9 @@ module.exports = {
       }
       
       // deploy script, routes, and namespaces
-      const namespaceResponse = await ms.deployNamespaces(this.provider.config.accountId, functionObject);
-      const workerScriptResponse = await ms.deployWorker(this.provider.config.accountId, functionObject);
-      const routesResponse = await ms.deployRoutes(this.provider.config.zoneId, functionObject);
+      const namespaceResponse = await allScripts.deployNamespaces(this.provider.config.accountId, functionObject);
+      const workerScriptResponse = await allScripts.deployEnterpriseWorker(this.provider.config.accountId, functionObject);
+      const routesResponse = await allScripts.deployRoutes(this.provider.config.zoneId, functionObject);
 
       return {
         workerScriptResponse,

--- a/shared/allScripts.js
+++ b/shared/allScripts.js
@@ -52,18 +52,37 @@ module.exports = {
 
   /**
    * Deploys the Worker Script in functionObject from the yml file
-   * @param {*} accountId 
-   * @param {*} functionObject 
+   * @param {*} accountId
+   * @param {*} functionObject
    */
-  async deployWorker(accountId, functionObject) {
+  async deployEnterpriseWorker(accountId, functionObject) {
     cf.setAccountId(accountId);
 
     const contents = generateCode(functionObject);
-    let bindings = await this.getBindings(functionObject.resources);
+    const bindings = await this.getBindings(functionObject.resources);
 
     return await cf.workers.deploy({
       accountId,
       name: functionObject.name,
+      script: contents,
+      bindings
+    })
+  },
+
+  /**
+   * Deploys the Worker Script in functionObject from the yml file
+   * @param {*} accountId
+   * @param {*} zoneId
+   * @param {*} functionObject
+   */
+  async deployWorker(accountId, zoneId, functionObject) {
+    cf.setAccountId(accountId);
+
+    const contents = generateCode(functionObject);
+    const bindings = await this.getBindings(functionObject.resources);
+
+    return await cf.workers.deploy({
+      zoneId,
       script: contents,
       bindings
     })

--- a/test/shared/allScripts_test.js
+++ b/test/shared/allScripts_test.js
@@ -1,7 +1,7 @@
 const proxyquire =  require('proxyquire')
 const assert = require('assert');
 
-const ms = proxyquire("../../shared/multiscript", {
+const allScripts = proxyquire("../../shared/allScripts", {
   "cloudflare-workers-toolkit": {
     
   }
@@ -21,7 +21,7 @@ const EVENTS = [{
 
 describe("getRoutes", function() {
   it("pulls routes out of the event config", function() {
-    const routes = ms.getRoutes(EVENTS);
+    const routes = allScripts.getRoutes(EVENTS);
     assert.deepEqual(routes, ['somedomain.com/route1', 'somedomain.com/route2'])
   });
 });


### PR DESCRIPTION
Workers KV namespace storage weren't supported on single scripts, and a lot of the code between multi and single scripts was duplicated.

This renames the `shared/multiscript.js` file to `shared/allScripts.js`, and uses that code in `deploy/lib/singlescript.js`. Consequentially, single scripts now support Workers KV.