### PR TITLE
Allow custom webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,13 @@ functions:
           method: GET
 ```
 
-To customize webpack config, you can pass config as value.
+To customize webpack config, you can pass config file path as value.
 
 ```yaml
 functions:
   myfunction:
     name: myfunction
-    webpack:
-      node:
-        fs: empty
-        tls: empty
+    webpack: ./webpack.config.js
     script: handlers/myfunctionhandler
     events:
       - http:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,25 @@ functions:
       - http:
           url: example.com/myfunction
           method: GET
-  
 ```
+
+To customize webpack config, you can pass config as value.
+
+```yaml
+functions:
+  myfunction:
+    name: myfunction
+    webpack:
+      node:
+        fs: empty
+        tls: empty
+    script: handlers/myfunctionhandler
+    events:
+      - http:
+          url: example.com/myfunction
+          method: GET
+```
+
 
 ### Environment Variables
 

--- a/utils/webpack.js
+++ b/utils/webpack.js
@@ -8,6 +8,7 @@ module.exports = {
     serverless.cli.log(`bundling: ${functionObject.script}`);
 
     let outputPath = path.join(serverless.config.servicePath, functionObject.script);
+    let webpackConfig = functionObject.webpack;
 
     let config = {
       entry: {
@@ -20,6 +21,11 @@ module.exports = {
       devtool: 'cheap-module-source-map',
       target: 'webworker',
       mode: 'production'
+    }
+
+    // Check whether webpackConfig is an object
+    if (webpackConfig === Object(webpackConfig)) {
+      config = Object.assign(config, webpackConfig);
     }
     try {
       let result = await webpack(config);

--- a/utils/webpack.js
+++ b/utils/webpack.js
@@ -23,11 +23,13 @@ module.exports = {
       mode: 'production'
     }
 
-    // Check whether webpackConfig is an object
-    if (webpackConfig === Object(webpackConfig)) {
-      config = Object.assign(config, webpackConfig);
-    }
     try {
+      // Check whether webpackConfig is a string
+      if (typeof webpackConfig == 'string') {
+        let configPath = path.join(serverless.config.servicePath, webpackConfig);
+        let fileConfig = require(configPath);
+        config = Object.assign(config, fileConfig);
+      }
       let result = await webpack(config);
       let errors = result.compilation.errors;
       if (Array.isArray(errors) && errors) {


### PR DESCRIPTION
The common use case is to mock those nodejs built-in modules required by 3rd party libraries.