### PR TITLE
Fix the script name validation

### DIFF
--- a/shared/validate.js
+++ b/shared/validate.js
@@ -55,11 +55,7 @@ module.exports = {
   },
 
   isValidScriptName(sname) {
-    const re = new RegExp("^[a-z0-9_][A-Za-z0-9-_]*$");
-    if (re.exec(sname)) {
-      return true;
-    }
-    return false;
+    return /^[a-z0-9_][a-z0-9-_]*$/.test(sname);
   },
   
   getInvalidScriptNames() {


### PR DESCRIPTION
Upper case letters are not allowed in the script name:
```
--> Error Code:10016
--> Error Message: "workers.api.error.invalid_script_name"
```