### PR TITLE
Add support for zoneless deployments (workers.dev only)

### DIFF
--- a/deploy/lib/multiscript.js
+++ b/deploy/lib/multiscript.js
@@ -34,10 +34,17 @@ module.exports = {
         const workerScriptResponse = await ms.deployWorker(this.provider.config.accountId, this.serverless, functionObject);
         const routesResponse = await ms.deployRoutes(this.provider.config.zoneId, functionObject);
 
+        let zonelessResponse;
+
+        if (functionObject.zoneless) {
+          zonelessResponse = await ms.deployZoneless(this.provider.config.accountId, functionObject);
+        }
+
         return {
           workerScriptResponse,
           routesResponse,
-          namespaceResponse
+          namespaceResponse,
+          zonelessResponse
         };
       });
   },

--- a/shared/accountType.js
+++ b/shared/accountType.js
@@ -22,11 +22,12 @@ const cf = require("cloudflare-workers-toolkit");
 
 module.exports = {
   async checkAccountType() {
+    const accountId = this.provider.config.accountId;
     const zoneId = this.provider.config.zoneId;
     return await BB.bind(this)
       .then(this.checkAllEnvironmentVariables)
       .then(function() {
-        return cf.workers.getSettings({zoneId});
+        return cf.workers.getSettings({zoneId, accountId});
       })
       .then(this.checkIfMultiScript)
   },

--- a/shared/duplicate.js
+++ b/shared/duplicate.js
@@ -33,6 +33,20 @@ module.exports = {
 
     const { zoneId } = provider.config;
 
+    const functions = serverless.service.getAllFunctions();
+
+    const hasRoutes = functions.some(scriptName => {
+      const functionObject = serverless.service.getFunction(scriptName);
+
+      if (functionObject.events && functionObject.events.length) {
+        return true;
+      }
+    });
+
+    if (!hasRoutes) {
+      return false;
+    }
+
     if (!zoneId) {
       throw("You must specify a Zone ID CLOUDFLARE_ZONE_ID");
     }
@@ -43,7 +57,6 @@ module.exports = {
     const foundDuplicate = result.some(filters => {
       const { pattern, script } = filters;
 
-      const functions = serverless.service.getAllFunctions();
       for (const scriptName of functions) {
         const functionObject = serverless.service.getFunction(scriptName);
         const routes = functionObject.events.map(function(event) {

--- a/shared/multiscript.js
+++ b/shared/multiscript.js
@@ -17,6 +17,7 @@
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 const cf = require("cloudflare-workers-toolkit");
+const sdk = require("../provider/sdk");
 const path = require("path");
 const { generateCode, generateWASM } = require("../deploy/lib/workerScript");
 
@@ -145,5 +146,18 @@ module.exports = {
     }
 
     return routeResponses;
+  },
+
+  async deployZoneless(accountId, functionObject) {
+      const name = functionObject.name;
+
+      const response = await sdk.cfApiCall({
+          url: `/accounts/${accountId}/workers/scripts/${name}/subdomain`,
+          method: `POST`,
+          contentType: 'application/json',
+          body: JSON.stringify({enabled: true})
+        });
+
+      return response;
   }
 }


### PR DESCRIPTION
Hi,

I did a quick implementation to hopefully resolve #36.

I tested the following `serverless.yml` file, and was able to successfully deploy the worker just to my workers.dev subdomain:

The additional toggle I added was "zoneless: true/false" which automatically enables the workers.dev route - this can also be used for zone-based functions. I figured this might be useful so you don't have to go into the UI and toggle the worker on after deployment.

```
service: zone-test

frameworkVersion: '2'

provider:
  name: cloudflare
  config:
    accountId: <account id here>

plugins:
  - serverless-cloudflare-workers

functions:
  hello:
    name: hello
    zoneless: true
    script: helloWorld # there must be a file called helloWorld.js
```

Let me know if there's any issues!